### PR TITLE
Use router links for more internal links

### DIFF
--- a/src/components/json.tsx
+++ b/src/components/json.tsx
@@ -1,5 +1,6 @@
 import VideoPlayer from "./video-player";
 import { createSignal, For } from "solid-js";
+import { A } from "@solidjs/router";
 
 interface AtBlob {
   $type: string;
@@ -25,17 +26,17 @@ const JSONString = ({ data }: { data: string }) => {
         {(part) => (
           <>
             {part.startsWith("at://") && part.split(" ").length === 1 ?
-              <a class="underline" href={part.replace("at://", "/at/")}>
+              <A class="underline" href={part.replace("at://", "/at/")}>
                 {part}
-              </a>
+              </A>
             : (
               part.startsWith("did:") &&
               part.split(" ").length === 1 &&
               part.split(":").length === 3
             ) ?
-              <a class="underline" href={`/at/${part}`}>
+              <A class="underline" href={`/at/${part}`}>
                 {part}
-              </a>
+              </A>
             : (
               isURL(part) &&
               ["http:", "https:", "web+at:"].includes(new URL(part).protocol) &&

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1,5 +1,5 @@
 import { resolveHandle } from "../utils/api.js";
-import { action, redirect, useSubmission } from "@solidjs/router";
+import { A, action, redirect, useSubmission } from "@solidjs/router";
 import Tooltip from "./tooltip.jsx";
 import { Show } from "solid-js";
 import { agent, loginState } from "../components/login.jsx";
@@ -69,9 +69,9 @@ const Search = () => {
             <Tooltip
               text="Repository"
               children={
-                <a href={`/at/${agent.sub}`} class="flex items-center">
+                <A href={`/at/${agent.sub}`} class="flex items-center">
                   <button class="i-tabler-binary-tree text-xl" />
-                </a>
+                </A>
               }
             />
           </Show>

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -1,5 +1,5 @@
 import { createSignal, ErrorBoundary, onMount, Show, Suspense } from "solid-js";
-import { RouteSectionProps, useLocation, useParams } from "@solidjs/router";
+import { A, RouteSectionProps, useLocation, useParams } from "@solidjs/router";
 import { agent, loginState, retrieveSession } from "./components/login.jsx";
 import { CreateRecord } from "./components/create.jsx";
 import Tooltip from "./components/tooltip.jsx";
@@ -47,20 +47,20 @@ const Layout = (props: RouteSectionProps<unknown>) => {
     >
       <div class="mb-2 flex w-[21rem] items-center">
         <div class="flex basis-1/3 gap-x-2">
-          <a href="/jetstream">
+          <A href="/jetstream">
             <Tooltip text="Jetstream">
               <div class="i-ic-outline-cell-tower text-xl" />
             </Tooltip>
-          </a>
+          </A>
           <AccountManager />
           <Show when={loginState()}>
             <CreateRecord />
           </Show>
         </div>
         <div class="basis-1/3 text-center font-mono text-xl font-bold">
-          <a href="/" class="hover:underline">
+          <A href="/" class="hover:underline">
             PDSls
-          </a>
+          </A>
         </div>
         <div class="justify-right flex basis-1/3 items-center gap-x-2">
           <a href="https://github.com/notjuliet/pdsls" target="_blank">

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -1,3 +1,5 @@
+import { A } from "@solidjs/router";
+
 const Home = () => {
   return (
     <div class="mt-4 flex w-full flex-col break-words">
@@ -26,23 +28,23 @@ const Home = () => {
             Jetstream
           </a>{" "}
           viewer is also available{" "}
-          <a href="/jetstream" class="text-lightblue-500 hover:underline">
+          <A href="/jetstream" class="text-lightblue-500 hover:underline">
             here
-          </a>
+          </A>
           .
         </p>
         <p>
-          <a
+          <A
             href="https://atproto.com/specs/sync#firehose"
             class="text-lightblue-500 hover:underline"
             target="_blank"
           >
             Firehose
-          </a>{" "}
+          </A>{" "}
           support can be found{" "}
-          <a href="/firehose" class="text-lightblue-500 hover:underline">
+          <A href="/firehose" class="text-lightblue-500 hover:underline">
             here
-          </a>
+          </A>
           .
         </p>
       </div>
@@ -51,33 +53,33 @@ const Home = () => {
         <div>
           <span class="font-semibold text-orange-400">PDS URL</span>:
           <div>
-            <a href="/pds.moe" class="text-lightblue-500 hover:underline">
+            <A href="/pds.moe" class="text-lightblue-500 hover:underline">
               https://pds.moe
-            </a>
+            </A>
           </div>
         </div>
         <div>
           <span class="font-semibold text-orange-400">AT URI</span> (at://
           optional, DID or handle alone also works):
           <div>
-            <a
+            <A
               href="/at/did:plc:oisofpd7lj26yvgiivf3lxsi/app.bsky.feed.post/3l2zpbbhuvw2h"
               class="text-lightblue-500 hover:underline"
             >
               at://did:plc:oisofpd7lj26yvgiivf3lxsi/app.bsky.feed.post/3l2zpbbhuvw2h
-            </a>
+            </A>
           </div>
         </div>
         <div>
           <span class="font-semibold text-orange-400">Bluesky Link</span> (posts
           and profiles):
           <div>
-            <a
+            <A
               href="/at/did:plc:vwzwgnygau7ed7b7wt5ux7y2/app.bsky.feed.post/3khpasmu4ou2l"
               class="text-lightblue-500 hover:underline"
             >
               https://bsky.app/profile/retr0.id/post/3khpasmu4ou2l
-            </a>
+            </A>
           </div>
         </div>
       </div>

--- a/src/views/labels.tsx
+++ b/src/views/labels.tsx
@@ -1,6 +1,6 @@
 import { createResource, createSignal, For, onMount, Show } from "solid-js";
 import { CredentialManager, XRPC } from "@atcute/client";
-import { useParams, useSearchParams } from "@solidjs/router";
+import { A, useParams, useSearchParams } from "@solidjs/router";
 import { labelerCache, resolvePDS } from "../utils/api.js";
 import { ComAtprotoLabelDefs } from "@atcute/client/lexicons";
 import { localDateFromTimestamp } from "../utils/date.js";
@@ -141,13 +141,13 @@ const LabelView = () => {
                     <div class="min-w-[5rem] font-semibold text-stone-600 dark:text-stone-400">
                       URI
                     </div>
-                    <a
+                    <A
                       href={`/at/${label.uri.replace("at://", "")}`}
                       target="_blank"
                       class="underline"
                     >
                       {label.uri}
-                    </a>
+                    </A>
                   </div>
                   <Show when={label.cid}>
                     <div class="flex gap-x-2">

--- a/src/views/pds.tsx
+++ b/src/views/pds.tsx
@@ -1,7 +1,7 @@
 import { createSignal, For, Show, createResource } from "solid-js";
 import { CredentialManager, XRPC } from "@atcute/client";
 import { ComAtprotoSyncListRepos } from "@atcute/client/lexicons";
-import { useParams } from "@solidjs/router";
+import { A, useParams } from "@solidjs/router";
 import { setPDS } from "../components/navbar";
 import Tooltip from "../components/tooltip";
 
@@ -55,7 +55,7 @@ const PdsView = () => {
         </p>
         <For each={repos()}>
           {(repo) => (
-            <a
+            <A
               href={`/at/${repo.did}`}
               classList={{
                 "w-full flex font-mono relative": true,
@@ -70,7 +70,7 @@ const PdsView = () => {
                 </Tooltip>
               </Show>
               <span class="w-full hover:underline">{repo.did}</span>
-            </a>
+            </A>
           )}
         </For>
         <div class="flex w-full justify-center">


### PR DESCRIPTION
some links broke when i swapped in the HashRouter to spin up pdsls on a simple http server. this tries to update all the internal links to use the router-aware `A` component (unless i missed any), so hash routing works!

i guess it's a no-op for local dev with vite, and for the real prod version, where real URLs reach the solidjs router.