### PR TITLE
Fix unsupported WASM

### DIFF
--- a/src/utils/wasm.ts
+++ b/src/utils/wasm.ts
@@ -1,0 +1,15 @@
+export const wasmSupported = (() => {
+  try {
+    if (
+      typeof WebAssembly === "object" &&
+      typeof WebAssembly.instantiate === "function"
+    ) {
+      const module = new WebAssembly.Module(
+        Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00),
+      );
+      if (module instanceof WebAssembly.Module)
+        return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
+    }
+  } catch (e) {}
+  return false;
+})();

--- a/src/views/record.tsx
+++ b/src/views/record.tsx
@@ -17,22 +17,7 @@ import {
 } from "../utils/api.js";
 import { theme } from "../components/settings.jsx";
 import { AtUri, uriTemplates } from "../utils/templates.js";
-
-const wasmSupported = (() => {
-  try {
-    if (
-      typeof WebAssembly === "object" &&
-      typeof WebAssembly.instantiate === "function"
-    ) {
-      const module = new WebAssembly.Module(
-        Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00),
-      );
-      if (module instanceof WebAssembly.Module)
-        return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
-    }
-  } catch (e) {}
-  return false;
-})();
+import { wasmSupported } from "../utils/wasm.js";
 
 export default () => {
   const params = useParams();

--- a/src/views/record.tsx
+++ b/src/views/record.tsx
@@ -77,7 +77,7 @@ export default () => {
       setRecord(res.data);
       setCID(res.data.cid);
       setExternalLink(checkUri(res.data.uri));
-      if (false) {
+      if (wasmSupported) {
         const publicTransport = await import("public-transport");
         await publicTransport.authenticate_post_with_doc(
           res.data.uri,

--- a/src/views/record.tsx
+++ b/src/views/record.tsx
@@ -86,6 +86,11 @@ export default () => {
           didDocCache[res.data.uri.split("/")[2]],
         );
         setValidRecord(true);
+      } else {
+        setNotice(
+          "Unable to validate record due to the browser not supporting WebAssembly.",
+        );
+        setValidRecord(false);
       }
     } catch (err: any) {
       if (err.message) setNotice(err.message);

--- a/src/views/record.tsx
+++ b/src/views/record.tsx
@@ -3,7 +3,6 @@ import { CredentialManager, XRPC } from "@atcute/client";
 import { ComAtprotoRepoGetRecord } from "@atcute/client/lexicons";
 import { action, query, redirect, useParams } from "@solidjs/router";
 import { JSONValue, syntaxHighlight } from "../components/json.jsx";
-import { authenticate_post_with_doc } from "public-transport";
 import { agent, loginState } from "../components/login.jsx";
 import { Editor } from "../components/editor.jsx";
 import { Backlinks } from "../components/backlinks.jsx";
@@ -78,8 +77,9 @@ export default () => {
       setRecord(res.data);
       setCID(res.data.cid);
       setExternalLink(checkUri(res.data.uri));
-      if (wasmSupported) {
-        await authenticate_post_with_doc(
+      if (false) {
+        const publicTransport = await import("public-transport");
+        await publicTransport.authenticate_post_with_doc(
           res.data.uri,
           res.data.cid!,
           res.data.value,


### PR DESCRIPTION
This should make PDSls work with Lockdown mode on iOS, it just won't be able to validate records, but won't make it crash the whole app anymore.