### PR TITLE
polywasm fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "prettier": "^3.5.2",
+    "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "typescript": "^5.8.2",
     "unocss": "66.1.0-beta.3",
@@ -27,8 +27,9 @@
     "@solidjs/router": "^0.15.3",
     "hls.js": "^1.5.20",
     "monaco-editor": "^0.52.2",
+    "polywasm": "^0.2.0",
     "public-transport": "file:pkg/pt.tgz",
     "solid-js": "^1.9.5"
   },
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
+  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       monaco-editor:
         specifier: ^0.52.2
         version: 0.52.2
+      polywasm:
+        specifier: ^0.2.0
+        version: 0.2.0
       public-transport:
         specifier: file:pkg/pt.tgz
         version: file:pkg/pt.tgz
@@ -43,11 +46,11 @@ importers:
         version: 1.9.5
     devDependencies:
       prettier:
-        specifier: ^3.5.2
-        version: 3.5.2
+        specifier: ^3.5.3
+        version: 3.5.3
       prettier-plugin-tailwindcss:
         specifier: ^0.6.11
-        version: 0.6.11(prettier@3.5.2)
+        version: 0.6.11(prettier@3.5.3)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -978,8 +981,8 @@ packages:
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
 
-  package-manager-detector@0.2.10:
-    resolution: {integrity: sha512-1wlNZK7HW+UE3eGCcMv3hDaYokhspuIeH6enXSnCL1eEZSVDsy/dYwo/4CczhUsrKLA1SSXB+qce8Glw5DEVtw==}
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
   parse5@7.2.1:
     resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
@@ -1003,6 +1006,9 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  polywasm@0.2.0:
+    resolution: {integrity: sha512-13Lg5S4fkF6onHsIeITWBnrPYhPe6iqdZCGJ8K+RAlL3qvGptPuWR4aQtULmbkGW2/XzXxWoHKlWsYRAvfcLnA==}
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -1063,8 +1069,8 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@3.5.2:
-    resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==}
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1072,8 +1078,8 @@ packages:
     resolution: {integrity: sha512-2Hyc8MnMTXkqSQzx3Ms+kT4kXMx1XXSfeCWOhPXHGd0TQwgJRuScDy3v+Xi7aHexq3OHNkIh4CP76AGljRL+pw==, tarball: file:pkg/pt.tgz}
     version: 0.1.0
 
-  quansync@0.2.6:
-    resolution: {integrity: sha512-u3TuxVTuJtkTxKGk5oZ7K2/o+l0/cC6J8SOyaaSnrnroqvcVy7xBxtvBUyd+Xa8cGoCr87XmQj4NR6W+zbqH8w==}
+  quansync@0.2.7:
+    resolution: {integrity: sha512-KZDFlN9/Si3CgKHZsIfLBsrjWKFjqu9KA0zDGJEQoQzPm5HWNDEFc2mkLeYUBBOwEJtxNBSMaNLE/GlvArIEfQ==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -1264,7 +1270,7 @@ snapshots:
 
   '@antfu/install-pkg@1.0.0':
     dependencies:
-      package-manager-detector: 0.2.10
+      package-manager-detector: 0.2.11
       tinyexec: 0.3.2
 
   '@antfu/utils@8.1.1': {}
@@ -2093,7 +2099,7 @@ snapshots:
     dependencies:
       mlly: 1.7.4
       pkg-types: 1.3.1
-      quansync: 0.2.6
+      quansync: 0.2.7
 
   lru-cache@5.1.1:
     dependencies:
@@ -2136,9 +2142,9 @@ snapshots:
       node-fetch-native: 1.6.6
       ufo: 1.5.4
 
-  package-manager-detector@0.2.10:
+  package-manager-detector@0.2.11:
     dependencies:
-      quansync: 0.2.6
+      quansync: 0.2.7
 
   parse5@7.2.1:
     dependencies:
@@ -2160,21 +2166,23 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
+  polywasm@0.2.0: {}
+
   postcss@8.5.3:
     dependencies:
       nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier-plugin-tailwindcss@0.6.11(prettier@3.5.2):
+  prettier-plugin-tailwindcss@0.6.11(prettier@3.5.3):
     dependencies:
-      prettier: 3.5.2
+      prettier: 3.5.3
 
-  prettier@3.5.2: {}
+  prettier@3.5.3: {}
 
   public-transport@file:pkg/pt.tgz: {}
 
-  quansync@0.2.6: {}
+  quansync@0.2.7: {}
 
   readdirp@3.6.0:
     dependencies:

--- a/src/views/record.tsx
+++ b/src/views/record.tsx
@@ -62,32 +62,19 @@ export default () => {
       setRecord(res.data);
       setCID(res.data.cid);
       setExternalLink(checkUri(res.data.uri));
-      if (wasmSupported) {
-        const publicTransport = await import("public-transport");
-        await publicTransport.authenticate_post_with_doc(
-          res.data.uri,
-          res.data.cid!,
-          res.data.value,
-          didDocCache[res.data.uri.split("/")[2]],
-        );
-        setValidRecord(true);
-      } else {
+      if (!wasmSupported) {
         // @ts-ignore
         const polywasm = await import("polywasm");
         globalThis.WebAssembly = polywasm.WebAssembly;
-        const publicTransport = await import("public-transport");
-        await publicTransport.authenticate_post_with_doc(
-          res.data.uri,
-          res.data.cid!,
-          res.data.value,
-          didDocCache[res.data.uri.split("/")[2]],
-        );
-        setValidRecord(true);
-        //setNotice(
-        //  "Unable to validate record due to the browser not supporting WebAssembly.",
-        //);
-        //setValidRecord(false);
       }
+      const publicTransport = await import("public-transport");
+      await publicTransport.authenticate_post_with_doc(
+        res.data.uri,
+        res.data.cid!,
+        res.data.value,
+        didDocCache[res.data.uri.split("/")[2]],
+      );
+      setValidRecord(true);
     } catch (err: any) {
       if (err.message) setNotice(err.message);
       else setNotice(`Invalid record: ${err}`);

--- a/src/views/record.tsx
+++ b/src/views/record.tsx
@@ -18,6 +18,7 @@ import {
 import { theme } from "../components/settings.jsx";
 import { AtUri, uriTemplates } from "../utils/templates.js";
 import { wasmSupported } from "../utils/wasm.js";
+import { authenticate_post_with_doc } from "public-transport";
 
 export default () => {
   const params = useParams();
@@ -62,21 +63,18 @@ export default () => {
       setRecord(res.data);
       setCID(res.data.cid);
       setExternalLink(checkUri(res.data.uri));
-      if (wasmSupported) {
-        const publicTransport = await import("public-transport");
-        await publicTransport.authenticate_post_with_doc(
-          res.data.uri,
-          res.data.cid!,
-          res.data.value,
-          didDocCache[res.data.uri.split("/")[2]],
-        );
-        setValidRecord(true);
-      } else {
-        setNotice(
-          "Unable to validate record due to the browser not supporting WebAssembly.",
-        );
-        setValidRecord(false);
+      if (!wasmSupported) {
+        // @ts-ignore
+        const polywasm = await import("polywasm");
+        globalThis.WebAssembly = polywasm.WebAssembly;
       }
+      await authenticate_post_with_doc(
+        res.data.uri,
+        res.data.cid!,
+        res.data.value,
+        didDocCache[res.data.uri.split("/")[2]],
+      );
+      setValidRecord(true);
     } catch (err: any) {
       if (err.message) setNotice(err.message);
       else setNotice(`Invalid record: ${err}`);

--- a/src/views/record.tsx
+++ b/src/views/record.tsx
@@ -18,7 +18,6 @@ import {
 import { theme } from "../components/settings.jsx";
 import { AtUri, uriTemplates } from "../utils/templates.js";
 import { wasmSupported } from "../utils/wasm.js";
-import { authenticate_post_with_doc } from "public-transport";
 
 export default () => {
   const params = useParams();
@@ -63,18 +62,32 @@ export default () => {
       setRecord(res.data);
       setCID(res.data.cid);
       setExternalLink(checkUri(res.data.uri));
-      if (!wasmSupported) {
+      if (wasmSupported) {
+        const publicTransport = await import("public-transport");
+        await publicTransport.authenticate_post_with_doc(
+          res.data.uri,
+          res.data.cid!,
+          res.data.value,
+          didDocCache[res.data.uri.split("/")[2]],
+        );
+        setValidRecord(true);
+      } else {
         // @ts-ignore
         const polywasm = await import("polywasm");
         globalThis.WebAssembly = polywasm.WebAssembly;
+        const publicTransport = await import("public-transport");
+        await publicTransport.authenticate_post_with_doc(
+          res.data.uri,
+          res.data.cid!,
+          res.data.value,
+          didDocCache[res.data.uri.split("/")[2]],
+        );
+        setValidRecord(true);
+        //setNotice(
+        //  "Unable to validate record due to the browser not supporting WebAssembly.",
+        //);
+        //setValidRecord(false);
       }
-      await authenticate_post_with_doc(
-        res.data.uri,
-        res.data.cid!,
-        res.data.value,
-        didDocCache[res.data.uri.split("/")[2]],
-      );
-      setValidRecord(true);
     } catch (err: any) {
       if (err.message) setNotice(err.message);
       else setNotice(`Invalid record: ${err}`);


### PR DESCRIPTION
If the browser does not support WASM, we use the [polywasm](https://github.com/evanw/polywasm) library as a fallback so record validation still works.